### PR TITLE
Actually call done()

### DIFF
--- a/tasks/pelican.js
+++ b/tasks/pelican.js
@@ -58,6 +58,9 @@ module.exports = function(grunt) {
             } else {
                 if (err && options.failOnError) {
                     grunt.warn(err);
+                    done(false);
+                } else {
+                  done(true);
                 }
             }
             grunt.log.errorlns(stderr);


### PR DESCRIPTION
done() is never called unless a callback is supplied. This causes tasks after pelican to not execute.
